### PR TITLE
update release workflow to generate macOS installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ jobs:
   build:
     runs-on: ubuntu-22.04 # explicitly use 22.04 for binary compatibility with older distros
     timeout-minutes: 30
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, macos-latest]
     steps:
     - name: Checkout source code
       uses: actions/checkout@v4
@@ -27,19 +30,47 @@ jobs:
         go-version-file: 'go.mod'
 
     - name: Build
+      if: matrix.os != 'macos-latest'
       run: |
-        make cross
+        make cross-non-darwin
+    
+    - name: Build macOS Installer
+      if: matrix.os == 'macos-latest'
+      run: |
+        cd packaging/darwin
+        make NO_CODESIGN=1 pkginstaller
+        rm -rf ../../bin/*
+        mv out/macadam-installer-macos-universal.pkg ../../bin/macadam-installer-macos-universal.pkg
 
     - uses: actions/upload-artifact@v4
       with:
-        name: macadam-binaries
+        name: macadam-binaries-${{ matrix.os }}
         path: bin/*
 
-    - name: Create release on github
+  create_release:
+    needs: build
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Download all artifacts
+      uses: actions/download-artifact@v4
+      with:
+        pattern: macadam-binaries-*
+        path: artifacts
+
+    - name: Create release on GitHub
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-          gh release create --draft --generate-notes --verify-tag ${{github.ref_name}}
-          cd bin
-          sha256sum * >> sha256sums
-          gh release upload ${{github.ref_name}} *
+        RELEASE_TAG=${{ github.ref_name }}
+        gh release create --draft --generate-notes --verify-tag "$RELEASE_TAG"
+
+        cd artifacts
+
+        # Upload Linux and Windows binaries
+        cd macadam-binaries-ubuntu-22.04          
+        sha256sum * >> sha256sums        
+        gh release upload "$RELEASE_TAG" *
+
+        # Upload macOS installer
+        cd ../macadam-binaries-macos-latest
+        gh release upload "$RELEASE_TAG" macadam-installer-macos-universal.pkg

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,9 @@ build: bin/macadam-$(DEFAULT_GOOS)-$(DEFAULT_GOARCH)
 TOOLS_DIR := tools
 include tools/tools.mk
 
-cross: bin/macadam-darwin-amd64 bin/macadam-darwin-arm64 bin/macadam-linux-amd64 bin/macadam-linux-arm64 bin/macadam-windows-amd64
+cross-non-darwin: bin/macadam-linux-amd64 bin/macadam-linux-arm64 bin/macadam-windows-amd64
+
+cross: cross-non-darwin bin/macadam-linux-amd64 bin/macadam-linux-arm64 bin/macadam-windows-amd64
 
 check: lint vendorcheck test
 


### PR DESCRIPTION
this patch updates the release workflow to include the logic to create the macOS installer (which will also install vfkit/gvproxy). The installer is NOT signed.

for windows and linux it works as before.